### PR TITLE
Double jump

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -174,8 +174,9 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
-  useSameCurve: 0
-  doubleJumpCurve:
+  airJumpsAllowed: 1
+  useSameCurve: 1
+  airJumpCurve:
     serializedVersion: 2
     m_Curve: []
     m_PreInfinity: 2
@@ -184,7 +185,7 @@ MonoBehaviour:
   onJump:
     m_PersistentCalls:
       m_Calls: []
-  onDoubleJump:
+  onAirJump:
     m_PersistentCalls:
       m_Calls: []
 --- !u!114 &1729414150543403562

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -30,7 +30,7 @@ Transform:
   m_GameObject: {fileID: 3326305250810700147}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -1.54, z: 0}
-  m_LocalScale: {x: 1, y: 2, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -99,18 +99,18 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.00003117323}
+  m_Offset: {x: 0, y: -0.60402584}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.64, y: 0.64}
+    oldSize: {x: 2, y: 2}
     newSize: {x: 1, y: 1}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1, y: 0.99993765}
+  m_Size: {x: 1, y: 0.71567535}
   m_EdgeRadius: 0
 --- !u!50 &3326305250810700159
 Rigidbody2D:
@@ -149,6 +149,7 @@ MonoBehaviour:
   acceleration: 25
   deacceleration: 5
   maxSpeed: 6
+  groundedDistance: 0.05
   jumpCurve:
     serializedVersion: 2
     m_Curve:
@@ -173,7 +174,17 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+  useSameCurve: 0
+  doubleJumpCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
   onJump:
+    m_PersistentCalls:
+      m_Calls: []
+  onDoubleJump:
     m_PersistentCalls:
       m_Calls: []
 --- !u!114 &1729414150543403562

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -74,7 +74,8 @@ public class PlayerController : MonoBehaviour {
 		if (xInput != 0) {
 			float newVelocityX = velocity.x + xInput * acceleration * Time.deltaTime;
 			velocity.x = Mathf.Clamp(newVelocityX, -maxSpeed, maxSpeed);
-		} else if (allowControls || isGrounded) {
+		}
+		else if (allowControls || isGrounded) {
 			velocity.x -= velocity.x * deacceleration * Time.deltaTime;
 		}
 
@@ -98,8 +99,10 @@ public class PlayerController : MonoBehaviour {
 		else if (doAirJump)
 			Jump(airJumpCurve, airJumpEndTime);
 
-		if (Mathf.Abs(rb2D.velocity.y) < 0.01f)
+		if (Mathf.Abs(rb2D.velocity.y) < 0.01f) {
 			doJump = false;
+			doAirJump = false;
+		}
 
 		if (!doJump || !doAirJump)
 			rb2D.velocity = new Vector2(velocity.x, rb2D.velocity.y + gravity * Time.deltaTime);

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -27,7 +27,6 @@ public class PlayerController : MonoBehaviour {
 
 	private Rigidbody2D rb2D;
 	private BoxCollider2D boxCollider;
-	private SpriteRenderer spriteRenderer;
 	private LayerMask groundLayer;
 	private Vector2 velocity;
 
@@ -109,11 +108,14 @@ public class PlayerController : MonoBehaviour {
 	}
 
 	private bool CheckIfGrounded() {
-		Vector3 position = transform.position;
-
-		Vector2 rayStartPosition = new Vector2(position.x, position.y - boxCollider.bounds.extents.y);
+		Vector2 colliderPosition = (Vector2)transform.position + boxCollider.offset;
+		Vector2 rayStartPosition = new Vector2(colliderPosition.x, colliderPosition.y - boxCollider.bounds.extents.y);
 
 		RaycastHit2D hit = Physics2D.Raycast(rayStartPosition,Vector2.down, groundedDistance, groundLayer);
+
+	#if UNITY_EDITOR
+		Debug.DrawRay(rayStartPosition, Vector3.down * groundedDistance, Color.red);
+	#endif
 
 		return hit.collider != null;
 	}

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -27,6 +27,7 @@ public class PlayerController : MonoBehaviour {
 
 	private Rigidbody2D rb2D;
 	private BoxCollider2D boxCollider;
+	private SpriteRenderer spriteRenderer;
 	private LayerMask groundLayer;
 	private Vector2 velocity;
 
@@ -59,6 +60,13 @@ public class PlayerController : MonoBehaviour {
 			airJumpsUsed = 0;
 
 		float xInput = allowControls ? Input.GetAxisRaw("Horizontal") : 0;
+
+		Vector3 scale = transform.localScale;
+		if (xInput > 0)
+			scale.x = 1;
+		else if (xInput < 0)
+			scale.x = -1;
+		transform.localScale = scale;
 
 		if (rb2D.velocity.x == 0)
 			velocity.x = 0;


### PR DESCRIPTION
## Summary
Fixes #13
The player can now jump while in the air.
Implemented a way to select the number of jumps allowed while in air.
Air jumps can follow a different curve if enabled.

A bit out of scope but now flips scale depending on movement.

## Visualisation
![u6wZL2di0z](https://user-images.githubusercontent.com/44698252/99678969-b15df180-2a7b-11eb-9dfc-f5b8fa73a846.gif)
