### PR TITLE
Reworked grounded detection and tweaked movement values

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -152,7 +152,7 @@ MonoBehaviour:
   acceleration: 25
   deacceleration: 7
   maxSpeed: 5
-  groundedDistance: 0.14
+  groundedCollider: {fileID: 4176820095388927488}
   jumpCurve:
     serializedVersion: 2
     m_Curve:
@@ -246,7 +246,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.028078318, y: -0.9410247}
+  m_Offset: {x: 0.017233372, y: -0.9410247}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -257,7 +257,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.49214125, y: 0.0692333}
+  m_Size: {x: 0.50422096, y: 0.0692333}
   m_EdgeRadius: 0
 --- !u!114 &1729414150543403562
 MonoBehaviour:

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 3326305250810700156}
   - component: {fileID: 3326305250810700159}
   - component: {fileID: 3326305250810700144}
+  - component: {fileID: 4176820095388927488}
   - component: {fileID: 1729414150543403562}
   - component: {fileID: 930851542}
   - component: {fileID: 930851549}
@@ -149,8 +150,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gravity: -19.64
   acceleration: 25
-  deacceleration: 5
-  maxSpeed: 6
+  deacceleration: 7
+  maxSpeed: 5
   groundedDistance: 0.14
   jumpCurve:
     serializedVersion: 2
@@ -232,6 +233,32 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!61 &4176820095388927488
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3326305250810700147}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.028078318, y: -0.9410247}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.875, y: 1.875}
+    newSize: {x: 1.875, y: 1.875}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.49214125, y: 0.0692333}
+  m_EdgeRadius: 0
 --- !u!114 &1729414150543403562
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level Example Scene.unity
+++ b/Assets/Scenes/Level Example Scene.unity
@@ -2012,7 +2012,7 @@ GameObject:
   - component: {fileID: 2106151315}
   m_Layer: 8
   m_Name: Tilemap
-  m_TagString: Ground
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/Level Example Scene.unity
+++ b/Assets/Scenes/Level Example Scene.unity
@@ -1573,6 +1573,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3326305250810700144, guid: e40218b980f2fc94483a2a4660c7161b, type: 3}
+      propertyPath: maxSpeed
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 3326305250810700147, guid: e40218b980f2fc94483a2a4660c7161b, type: 3}
       propertyPath: m_Name
       value: Player
@@ -2008,7 +2012,7 @@ GameObject:
   - component: {fileID: 2106151315}
   m_Layer: 8
   m_Name: Tilemap
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -16,6 +16,7 @@ public class PlayerController : MonoBehaviour {
 	[SerializeField] private float maxSpeed = 3;
 
 	[Header("Jumping")]
+	[SerializeField] private BoxCollider2D groundedCollider = null;
 	[SerializeField] private AnimationCurve jumpCurve = null;
 	[SerializeField] private int airJumpsAllowed = 1;
 	[SerializeField] private bool useSameCurve;
@@ -59,6 +60,8 @@ public class PlayerController : MonoBehaviour {
 	}
 
 	private void Update() {
+		isGrounded = groundedCollider.IsTouchingLayers(groundLayer);
+
 		if (isGrounded)
 			airJumpsUsed = 0;
 
@@ -74,6 +77,7 @@ public class PlayerController : MonoBehaviour {
 		if (Mathf.Abs(rb2D.velocity.x) < 0.01f)
 			velocity.x = 0;
 
+		// Cancels jumps if head hits roof
 		if (Mathf.Abs(rb2D.velocity.y) < 0.01f && !isGrounded) {
 			doJump = false;
 			doAirJump = false;
@@ -83,7 +87,7 @@ public class PlayerController : MonoBehaviour {
 			float newVelocityX = velocity.x + xInput * acceleration * Time.deltaTime;
 			velocity.x = Mathf.Clamp(newVelocityX, -maxSpeed, maxSpeed);
 		}
-		else if (allowControls || isGrounded) {
+		else if ((allowControls || isGrounded) && velocity.x > 0) {
 			velocity.x -= velocity.x * deacceleration * Time.deltaTime;
 		}
 
@@ -111,16 +115,6 @@ public class PlayerController : MonoBehaviour {
 
 		if (!doJump || !doAirJump)
 			rb2D.velocity = new Vector2(velocity.x, rb2D.velocity.y + gravity * Time.deltaTime);
-	}
-
-	private void OnTriggerEnter2D(Collider2D other) {
-		if (other.CompareTag("Ground"))
-			isGrounded = true;
-	}
-
-	private void OnTriggerExit2D(Collider2D other) {
-		if (other.CompareTag("Ground"))
-			isGrounded = false;
 	}
 
 	private void BeginJump(UnityEvent e) {

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -60,8 +60,6 @@ public class PlayerController : MonoBehaviour {
 	}
 
 	private void Update() {
-		isGrounded = groundedCollider.IsTouchingLayers(groundLayer);
-
 		if (isGrounded)
 			airJumpsUsed = 0;
 
@@ -87,7 +85,7 @@ public class PlayerController : MonoBehaviour {
 			float newVelocityX = velocity.x + xInput * acceleration * Time.deltaTime;
 			velocity.x = Mathf.Clamp(newVelocityX, -maxSpeed, maxSpeed);
 		}
-		else if ((allowControls || isGrounded) && velocity.x > 0) {
+		else if ((allowControls || isGrounded) && velocity.x != 0) {
 			velocity.x -= velocity.x * deacceleration * Time.deltaTime;
 		}
 
@@ -115,6 +113,16 @@ public class PlayerController : MonoBehaviour {
 
 		if (!doJump || !doAirJump)
 			rb2D.velocity = new Vector2(velocity.x, rb2D.velocity.y + gravity * Time.deltaTime);
+	}
+
+	private void OnTriggerEnter2D(Collider2D other) {
+		if (groundedCollider.IsTouchingLayers(groundLayer))
+			isGrounded = true;
+	}
+
+	private void OnTriggerExit2D(Collider2D other) {
+		if (!groundedCollider.IsTouchingLayers(groundLayer))
+			isGrounded = false;
 	}
 
 	private void BeginJump(UnityEvent e) {

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -16,7 +16,6 @@ public class PlayerController : MonoBehaviour {
 	[SerializeField] private float maxSpeed = 3;
 
 	[Header("Jumping")]
-	[SerializeField] private float groundedDistance = 0.05f;
 	[SerializeField] private AnimationCurve jumpCurve = null;
 	[SerializeField] private int airJumpsAllowed = 1;
 	[SerializeField] private bool useSameCurve;
@@ -60,7 +59,6 @@ public class PlayerController : MonoBehaviour {
 	}
 
 	private void Update() {
-		isGrounded = CheckIfGrounded();
 		if (isGrounded)
 			airJumpsUsed = 0;
 
@@ -73,8 +71,13 @@ public class PlayerController : MonoBehaviour {
 			scale.x = -1;
 		transform.localScale = scale;
 
-		if (rb2D.velocity.x == 0)
+		if (Mathf.Abs(rb2D.velocity.x) < 0.01f)
 			velocity.x = 0;
+
+		if (Mathf.Abs(rb2D.velocity.y) < 0.01f && !isGrounded) {
+			doJump = false;
+			doAirJump = false;
+		}
 
 		if (xInput != 0) {
 			float newVelocityX = velocity.x + xInput * acceleration * Time.deltaTime;
@@ -106,26 +109,18 @@ public class PlayerController : MonoBehaviour {
 		else if (doAirJump)
 			Jump(airJumpCurve, airJumpEndTime);
 
-		if (Mathf.Abs(rb2D.velocity.y) < 0.01f) {
-			doJump = false;
-			doAirJump = false;
-		}
-
 		if (!doJump || !doAirJump)
 			rb2D.velocity = new Vector2(velocity.x, rb2D.velocity.y + gravity * Time.deltaTime);
 	}
 
-	private bool CheckIfGrounded() {
-		Vector2 colliderPosition = (Vector2)transform.position + playerCollider.offset;
-		Vector2 rayStartPosition = new Vector2(colliderPosition.x, colliderPosition.y - playerCollider.bounds.extents.y);
+	private void OnTriggerEnter2D(Collider2D other) {
+		if (other.CompareTag("Ground"))
+			isGrounded = true;
+	}
 
-		RaycastHit2D hit = Physics2D.Raycast(rayStartPosition,Vector2.down, groundedDistance, groundLayer);
-
-	#if UNITY_EDITOR
-		Debug.DrawRay(rayStartPosition, Vector3.down * groundedDistance, Color.red);
-	#endif
-
-		return hit.collider != null;
+	private void OnTriggerExit2D(Collider2D other) {
+		if (other.CompareTag("Ground"))
+			isGrounded = false;
 	}
 
 	private void BeginJump(UnityEvent e) {

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,8 +3,7 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags:
-  - Ground
+  tags: []
   layers:
   - Default
   - TransparentFX

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Ground
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## Summary
Fixes #34
Now uses a collider to check if player is grounded.
~~This now uses the tag "Ground" instead of the "Ground" layer.~~

Values changed
- Deacceleration 5 --> 7
- Max speed 6 --> 5

## Visualisation
![yqCRo577nN](https://user-images.githubusercontent.com/44698252/99886245-34797600-2c3b-11eb-94c4-9857c204e994.gif)