### PR TITLE
No longer undetectable during transformation

### DIFF
--- a/Assets/Scripts/Enemy/Detection.cs
+++ b/Assets/Scripts/Enemy/Detection.cs
@@ -51,7 +51,7 @@ public class Detection : MonoBehaviour {
 
 		if (hit.rigidbody != null && hit.rigidbody.CompareTag("Player")) {
 			Transformation transformation = hit.rigidbody.GetComponent<Transformation>();
-			if (transformation == null || transformation.TransformationState == TransformationStates.Wolf)
+			if (transformation == null || transformation.State != TransformationState.Human)
 				return true;
 		}
 

--- a/Assets/Scripts/Player/PlayerAnimationController.cs
+++ b/Assets/Scripts/Player/PlayerAnimationController.cs
@@ -38,10 +38,10 @@ public class PlayerAnimationController : MonoBehaviour {
 
 	public void TransformStart() {
 		animator.SetFloat(transformSpeedHash, 1f / (transformation.TransformDuration / transformAnimation.length));
-		animator.SetBool(isHumanHash, transformation.TransformationState != TransformationStates.Human);
+		animator.SetBool(isHumanHash, transformation.OldState != TransformationState.Human);
 	}
 
 	public void TransformInterrupt() {
-		animator.SetBool(isHumanHash, transformation.TransformationState == TransformationStates.Human);
+		animator.SetBool(isHumanHash, transformation.OldState == TransformationState.Human);
 	}
 }


### PR DESCRIPTION
## Summary
Fixes #32
Added a third transformation state, "Transforming".
Now remembers your old state when transforming in line with a new state being added.
Made a slight rename on transformationState as it felt a bit too closely related to the the Enum TransformationStates which IMO fit better in singular.

## Visualisation
![1RVxVA0ciM](https://user-images.githubusercontent.com/44698252/99886788-8f14d100-2c3f-11eb-81ca-9067b933b98e.gif)
