### PR TITLE
Disables player controls while deathscreen is active

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1626,6 +1626,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 3326305250810700144}
+        m_TargetAssemblyTypeName: PlayerController, Assembly-CSharp
+        m_MethodName: InterruptDash
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &-2577431829083161899
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1602,6 +1602,30 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 2928980542965478383}
+        m_TargetAssemblyTypeName: Knockbackable, Assembly-CSharp
+        m_MethodName: InterruptKnockback
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 3326305250810700144}
+        m_TargetAssemblyTypeName: PlayerController, Assembly-CSharp
+        m_MethodName: set_DoKnockBack
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &-2577431829083161899
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Common/DamageArea.cs
+++ b/Assets/Scripts/Common/DamageArea.cs
@@ -64,6 +64,9 @@ public class DamageArea : MonoBehaviour {
 
 		Vector2 avgContactPoint = GetAvgContactPoint(other);
 
+		if (enableKnockback)
+			DoKnockback(other, avgContactPoint);
+
 		Health healthComponent = other.attachedRigidbody.GetComponent<Health>();
 		if (healthComponent != null) {
 			cooldownTimer = damageCooldown;
@@ -73,9 +76,6 @@ public class DamageArea : MonoBehaviour {
 			if (effectTarget.Length != 0 && other.attachedRigidbody.CompareTag(effectTarget))
 				onDamageEffect.Invoke(avgContactPoint);
 		}
-
-		if (enableKnockback)
-			DoKnockback(other, avgContactPoint);
 	}
 
 	private void DoKnockback(Collider2D other, Vector2 point) {

--- a/Assets/Scripts/Common/Knockbackable.cs
+++ b/Assets/Scripts/Common/Knockbackable.cs
@@ -34,12 +34,21 @@ public class Knockbackable : MonoBehaviour {
 	private void FixedUpdate() {
 		if (doKnockback)
 			rb2D.velocity = velocity;
-}
+	}
 
 	private IEnumerator CoKnockbackDuration(float duration) {
 		yield return new WaitForSeconds(duration);
 		onKnockbackEnd.Invoke();
 		knockbackDurationRoutine = null;
 		doKnockback = false;
+	}
+
+	public void InterruptKnockback() {
+		if (!doKnockback) return;
+
+		doKnockback = false;
+
+		if (knockbackDurationRoutine != null)
+			StopCoroutine(knockbackDurationRoutine);
 	}
 }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -415,7 +415,7 @@ public class PlayerController : MonoBehaviour {
 		dashTimer += Time.deltaTime;
 	}
 
-	private void InterruptDash() {
+	public void InterruptDash() {
 		allowControls = true;
 		doGravity = true;
 		dashTimer = 0;

--- a/Assets/Scripts/UI/DeathScreenHelper.cs
+++ b/Assets/Scripts/UI/DeathScreenHelper.cs
@@ -19,6 +19,7 @@ public class DeathScreenHelper : MonoBehaviour {
 
 	private Health playerHealth;
 	private Transformation playerTransformation;
+	private PlayerController playerController;
 	private Animator animator;
 	private CheckpointManager checkpointManager;
 
@@ -33,6 +34,7 @@ public class DeathScreenHelper : MonoBehaviour {
 		GameObject go = GameObject.FindWithTag("Player");
 		playerHealth = go.GetComponent<Health>();
 		playerTransformation = go.GetComponent<Transformation>();
+		playerController = go.GetComponent<PlayerController>();
 	}
 
 	private void Start() {
@@ -58,17 +60,19 @@ public class DeathScreenHelper : MonoBehaviour {
 
 	private IEnumerator CoShowDeath() {
 		Time.timeScale = 0;
+		playerController.AllowControls = false;
 		animator.SetTrigger(showHash);
 
-		yield return new WaitForSecondsRealtime(screenDuration / 2);
-
 		if (checkpointManager != null) {
+			yield return new WaitForSecondsRealtime(screenDuration / 2);
 			checkpointManager.Respawn();
 			Time.timeScale = 1;
+			yield return new WaitForSeconds(screenDuration / 2);
+			playerController.AllowControls = true;
 			yield break;
 		}
 
-		yield return new WaitForSecondsRealtime(screenDuration / 2);
+		yield return new WaitForSecondsRealtime(screenDuration);
 		Time.timeScale = 1;
 		sceneHelper.ReloadScene();
 	}


### PR DESCRIPTION
## Summary
Fixes 261

Disables the controls while the deathscreen is inactive. 
this required interrupting knockback on death which also makes the respawn position more consistent.