### PR TITLE
322 Mute timed lever when paused

### DIFF
--- a/Assets/Prefabs/Puzzle/TimedLever.prefab
+++ b/Assets/Prefabs/Puzzle/TimedLever.prefab
@@ -87,6 +87,10 @@ PrefabInstance:
       propertyPath: m_Controller
       value: 
       objectReference: {fileID: 9100000, guid: 816001bb494ea9c419bf3d9f77c957e6, type: 2}
+    - target: {fileID: 1341724110450495477, guid: ea84000f640168144973836afabd90a8, type: 3}
+      propertyPath: m_UpdateMode
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1341724110450495478, guid: ea84000f640168144973836afabd90a8, type: 3}
       propertyPath: m_Name
       value: TimedLever

--- a/Assets/Scripts/Puzzle/Lever.cs
+++ b/Assets/Scripts/Puzzle/Lever.cs
@@ -28,8 +28,16 @@ public class Lever : SignalEmitter {
 		if (IsActivated && leverType == LeverType.Timed) {
 			leverTimer += Time.deltaTime;
 
-			if (leverTimer >= timerEnd)
+			if (leverTimer >= timerEnd) {
 				Deactivate();
+			}
+			else {
+				AudioSource currentAudio = hasStartedFastTimeSound ? fastTimeAudio : slowTimeAudio;
+				if (Time.timeScale == 0)
+					currentAudio.Pause();
+				else
+					currentAudio.UnPause();
+			}
 		}
 
 		if (!hasStartedFastTimeSound && leverType == LeverType.Timed && leverTimer >= fastTimeAudioStart) {


### PR DESCRIPTION
I originally intended to mute all sound effects when the game was paused. But as some effects are still needed to be played (like the ui clicks), I instead opted to just muting the timed lever ticking sound as this was the reason we wanted to do this in the first place. Doing this had the added side effect of not starting the ticking until after the camera pan which is much better in my opinion.

I also made the blinking stop when paused.