### PR TITLE
Fix hardlock when dying during the "Exit To Menu" transition

### DIFF
--- a/Assets/Prefabs/UI/Scene Transition.prefab
+++ b/Assets/Prefabs/UI/Scene Transition.prefab
@@ -189,7 +189,7 @@ Animator:
   m_Avatar: {fileID: 0}
   m_Controller: {fileID: 9100000, guid: fbbe3bbd3070c4748a8bb7dcc4b7e420, type: 2}
   m_CullingMode: 0
-  m_UpdateMode: 0
+  m_UpdateMode: 2
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_WarningMessage: 
@@ -211,7 +211,6 @@ MonoBehaviour:
   animator: {fileID: 399040299444584172}
   transitionClip: {fileID: 7400000, guid: 03b5ca3bdc6fdbc40ac11183ac4467c5, type: 2}
   mixer: {fileID: 24100000, guid: d5cbaa40cdec63f44affda746ccc1f16, type: 2}
-  sceneHelper: {fileID: 11400000, guid: 692a16753472ad946984312747c75dc8, type: 2}
 --- !u!114 &6791339038229454286
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/UI/Helpers/SceneTransitionHelper.cs
+++ b/Assets/Scripts/UI/Helpers/SceneTransitionHelper.cs
@@ -32,6 +32,7 @@ public class SceneTransitionHelper : MonoBehaviour {
 		mixer.GetFloat("masterVolume", out baseVolume);
 		baseVolume = MathX.DecibelsToLinear(baseVolume);
 
+		Time.timeScale = 0;
 		StartCoroutine(CoExit());
 	}
 
@@ -48,6 +49,7 @@ public class SceneTransitionHelper : MonoBehaviour {
 			yield return null;
 
 		loadOperation.allowSceneActivation = true;
+		Time.timeScale = 1;
 		StartCoroutine(CoEnter());
 	}
 

--- a/Assets/Scripts/UI/Helpers/SceneTransitionHelper.cs
+++ b/Assets/Scripts/UI/Helpers/SceneTransitionHelper.cs
@@ -32,7 +32,6 @@ public class SceneTransitionHelper : MonoBehaviour {
 		mixer.GetFloat("masterVolume", out baseVolume);
 		baseVolume = MathX.DecibelsToLinear(baseVolume);
 
-		Time.timeScale = 0;
 		StartCoroutine(CoExit());
 	}
 

--- a/Assets/Scripts/UI/Menus/PauseMenu.cs
+++ b/Assets/Scripts/UI/Menus/PauseMenu.cs
@@ -68,7 +68,6 @@ public class PauseMenu : MonoBehaviour {
 	}
 
 	public void ExitToMenu() {
-		Time.timeScale = 1;
 		sceneHelper.LoadSceneWithTransition(sceneHelper.MenuScene);
 	}
 


### PR DESCRIPTION
### Repro
> When you press "Exit To Menu" the game doesn't pause, thus allow you to keep falling and die while doing so. Once you load into a new level (can be a different one, or the same one, it doesn't matter), then you will hardlock. You can turn left and right, press Y to hear transformation sound or Jump to hear the jumping sound (neither will actually have any effect though). Pausing doesn't work either. Now if you Dash then you will freeze permanently, so any of the previously mentioned actions stop working. At this point closing the game with Alt+F4 is the only solution.

\- Nordanix

### Cause
The death screen freezes the time, but because a new scene is loaded it doesn't get a chance to set it back. This leaves the game with a time scale of 0.

### Changes
- Keep the time frozen while doing the "Exit To Menu" transition
- Reset the time scale after fading out a scene
- Make the scene transition animator run in unscaled time